### PR TITLE
Added headless functionality. Split the enum using enumset to allow s…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <version>5.7.1</version>
       <scope>test</scope>
     </dependency>

--- a/src/test/java/com/sparta/eng82/components/webdriver/WebDriverFactory.java
+++ b/src/test/java/com/sparta/eng82/components/webdriver/WebDriverFactory.java
@@ -1,7 +1,9 @@
 package com.sparta.eng82.components.webdriver;
 
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeDriver;
 
 public class WebDriverFactory {
@@ -21,11 +23,17 @@ public class WebDriverFactory {
             case EDGE:
                 driver = new EdgeDriver();
                 break;
+            case CHROME_HEADLESS:
+                ChromeOptions options = new ChromeOptions();
+                options.addArguments("headless");
+                driver = new ChromeDriver(options);
+                break;
             default:
                 driver = null;
                 break;
 
         }
+        driver.manage().window().setSize(new Dimension(375,812));
         return driver;
     }
 }

--- a/src/test/java/com/sparta/eng82/components/webdriver/WebDriverTests.java
+++ b/src/test/java/com/sparta/eng82/components/webdriver/WebDriverTests.java
@@ -1,25 +1,56 @@
 package com.sparta.eng82.components.webdriver;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
 
 //TODO Remove this for final release - just for testing currently
 
 public class WebDriverTests {
 
     static WebDriver driver;
+    static WebDriverFactory webDriverFactory;
+
+    public static final EnumSet<WebDriverTypes> normalTypes = EnumSet.of(WebDriverTypes.CHROME, WebDriverTypes.EDGE);
+    public static EnumSet<WebDriverTypes> headlessTypes = EnumSet.of(WebDriverTypes.CHROME_HEADLESS);
+
+    @BeforeAll
+    static void setup(){
+        webDriverFactory = new WebDriverFactory();
+    }
 
     @ParameterizedTest
-    @EnumSource(WebDriverTypes.class)
+    @MethodSource("normalTypesTest")
+    @DisplayName("Test all normal types")
     void testAllDriverTypes(WebDriverTypes webDriverType){
-        WebDriverFactory webDriverFactory = new WebDriverFactory();
         driver = webDriverFactory.getWebDriver(webDriverType);
-        driver.manage().window().setSize(new Dimension(375,812));
         driver.get("http://localhost:8080");
+        Assertions.assertEquals("http://localhost:8080/login", driver.getCurrentUrl());
+    }
+
+    private static Set<WebDriverTypes> normalTypesTest(){
+        return normalTypes;
+    }
+
+    @ParameterizedTest
+    @MethodSource("headlessTypesTest")
+    @DisplayName("Testing headless")
+    void testingHeadless(WebDriverTypes webDriverType) {
+       driver = webDriverFactory.getWebDriver(WebDriverTypes.CHROME_HEADLESS);
+       driver.get("http://localhost:8080");
+        Assertions.assertEquals("http://localhost:8080/login", driver.getCurrentUrl());
+    }
+
+    private static Set<WebDriverTypes> headlessTypesTest(){
+        return headlessTypes;
     }
 
     @AfterEach

--- a/src/test/java/com/sparta/eng82/components/webdriver/WebDriverTypes.java
+++ b/src/test/java/com/sparta/eng82/components/webdriver/WebDriverTypes.java
@@ -1,5 +1,10 @@
 package com.sparta.eng82.components.webdriver;
 
+import java.util.EnumSet;
+
 public enum WebDriverTypes {
-    CHROME, EDGE
+    CHROME, EDGE,
+    CHROME_HEADLESS
+
+
 }


### PR DESCRIPTION
…eparate running of tests headlessly depending on tester's requirements. This was a massive headache as junit doesn't provide a nice way to pass in collections as args for parameterised tests. It now uses a method source which will need to be explained in the documentation to testers. This method maybe be able to be abstracted out